### PR TITLE
Immutable support

### DIFF
--- a/example/src/components/container.js
+++ b/example/src/components/container.js
@@ -55,7 +55,7 @@ Container.contextTypes = {
 };
 
 Container.propTypes = {
-  notifications: PropTypes.array
+  notifications: PropTypes.object
 };
 
 export default connect(

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "redux": "^3.5.2"
   },
   "dependencies": {
+    "immutable": "^3.8.1",
     "react": "^0.14 || ^15.0.0-rc || ^15.0",
     "react-dom": "^0.14 || ^15.0.0-rc || ^15.0",
     "react-notification-system": "^0.2.7"

--- a/src/__tests__/notifications.js
+++ b/src/__tests__/notifications.js
@@ -9,12 +9,12 @@ describe('NotificationsComponent', () => {
     expect(wrapper.children()).toBeDefined();
   });
 
-  it('should warn if prop:notifications is not array', () => {
+  it('should warn if prop:notifications is not object', () => {
     spyOn(console, 'error');
 
     const wrapper = shallow(<Component notifications={1} />);
     const warning = console.error.calls.argsFor(0)[0];
 
-    expect(warning).toMatch(/Invalid prop `notifications` of type `number` supplied to `Notifications`, expected `array`./);
+    expect(warning).toMatch(/Invalid prop `notifications` of type `number` supplied to `Notifications`, expected `object`./);
   });
 });

--- a/src/__tests__/reducer.js
+++ b/src/__tests__/reducer.js
@@ -1,25 +1,26 @@
+import { List, toJS } from 'immutable'
 import Reducer from '../reducer';
 import * as Actions from '../actions';
 
 describe('reducer', () => {
   it('initializes state with an array', () => {
-    expect(Reducer()).toEqual([]);
+    expect(Reducer().toJS()).toEqual([]);
   });
 
   it('stores the notification to state', () => {
     const action = Actions.success();
-    const state = Reducer([], action);
+    const state = Reducer(List([]), action);
 
-    expect(state.length).toEqual(1);
+    expect(state.size).toEqual(1);
   });
 
   it('stores and removes notification', () => {
     const uid = 1;
 
-    const state = Reducer([], Actions.success({ uid }));
-    expect(state.length).toEqual(1);
+    const state = Reducer(List([]), Actions.success({ uid }));
+    expect(state.size).toEqual(1);
 
     const newState = Reducer(state, Actions.hide(uid));
-    expect(newState.length).toEqual(0);
+    expect(newState.size).toEqual(0);
   });
 });

--- a/src/notifications.js
+++ b/src/notifications.js
@@ -12,7 +12,7 @@ class Notifications extends React.Component {
   }
 
   componentWillReceiveProps(nextProps) {
-    const {notifications} = nextProps;
+    const notifications = nextProps.notifications.toJS();
     const notificationIds = notifications.map(notification => notification.uid);
 
     // Get all active notifications from react-notification-system
@@ -48,7 +48,7 @@ class Notifications extends React.Component {
 }
 
 Notifications.propTypes = {
-  notifications: PropTypes.array
+  notifications: PropTypes.object
 };
 
 Notifications.contextTypes = {

--- a/src/reducer.js
+++ b/src/reducer.js
@@ -1,13 +1,12 @@
+import { List } from 'immutable';
 import {RNS_SHOW_NOTIFICATION, RNS_HIDE_NOTIFICATION} from './const';
 
-export default function Notifications(state = [], action = {}) {
+export default function Notifications(state = List([]), action = {}) {
   switch(action.type) {
     case RNS_SHOW_NOTIFICATION:
       const { type, ...rest } = action;
-      return [
-        ...state,
-        { ...rest, uid: action.uid}
-      ];
+      return state.push({ ...rest, uid: action.uid });
+
     case RNS_HIDE_NOTIFICATION:
       return state.filter(notification => {
         return notification.uid !== action.uid;


### PR DESCRIPTION
This adds support for [immutable](https://facebook.github.io/immutable-js/) stores. 

It does so by making the notification store immutable itself.  This works if `store.notifications` is handled abstractly by the consumer as documented, even if the consumer itself isn't using immutable elsewhere (as in the example).   

In other words, this change allows `react-notification-system-redux` to be compatible with both immutable and plain old object stores, whereas previously it was only compatible with plain object stores. 

Of course, this approach will break anyone who is using `store.notifications` outside of `react-notification-system-redux`, since it changes the structure of said object.   Not sure how much of a concern that is though.
