### PR TITLE
Bug fix: messages not displayed that were added to the state tree before the component finished mounting

### DIFF
--- a/src/notifications.js
+++ b/src/notifications.js
@@ -11,7 +11,7 @@ class Notifications extends React.Component {
     return this.refs.notify;
   }
 
-  componentWillReceiveProps(nextProps) {
+  updateNotificationSystem(nextProps) {
     const {notifications} = nextProps;
     const notificationIds = notifications.map(notification => notification.uid);
 
@@ -34,6 +34,14 @@ class Notifications extends React.Component {
     });
   }
 
+  componentWillReceiveProps(nextProps) {
+    this.updateNotificationSystem(nextProps);
+  }
+
+  componentDidMount() {
+    this.updateNotificationSystem(this.props)
+  }
+
   shouldComponentUpdate(nextProps) {
     return this.props !== nextProps;
   }
@@ -42,7 +50,7 @@ class Notifications extends React.Component {
     const {notifications, ...rest} = this.props;
 
     return (
-      <NotifySystem ref='notify' { ...rest } />
+        <NotifySystem ref='notify' { ...rest } />
     );
   }
 }


### PR DESCRIPTION
Thanks for the great lib. I thought I'd throw this bug fix back to you. It will now display messages that were added to the redux state tree prior to the component mounting.