### PR TITLE
Remove unnecessary console log output

### DIFF
--- a/lib/notifications.js
+++ b/lib/notifications.js
@@ -70,7 +70,6 @@ var Notifications = function (_React$Component) {
           /// and remove all where uid is not found in the reducer
           systemNotifications.forEach(function (notification) {
             if (notificationIds.indexOf(notification.uid) < 0) {
-              console.log('removing', _this2.system().state.notifications);
               _this2.system().removeNotification(notification.uid);
             }
           });

--- a/src/notifications.js
+++ b/src/notifications.js
@@ -22,7 +22,6 @@ class Notifications extends React.Component {
       /// and remove all where uid is not found in the reducer
       (systemNotifications).forEach(notification => {
         if (notificationIds.indexOf(notification.uid) < 0) {
-          console.log('removing', this.system().state.notifications);
           this.system().removeNotification(notification.uid);
         }
       });


### PR DESCRIPTION
I am using your React wrapper for the Notification System at a project I am currently working on and try to only show one notification at most. To make this work I use the `hideNotification` action to hide an currently displayed notification.
This makes your wrapper remove the notification from the store which is correct behavior. But I recognized, that every removed notification leads to a `console.log` output, which gets kinda annoying and really shouldn't be happening in production.
So I removed this output completely in the code, if it might be important in development environment, maybe just disable it in production mode?